### PR TITLE
Gaia formig

### DIFF
--- a/src/buildings.ts
+++ b/src/buildings.ts
@@ -2,6 +2,7 @@ import { Building, Faction } from "..";
 
 export function upgradedBuildings(currentBuilding: Building, faction: Faction): Building[] {
   switch (currentBuilding) {
+    case Building.GaiaFormer: return [Building.Mine];
     case Building.Mine: return [Building.TradingStation];
     case Building.TradingStation: return faction === Faction.Bescods ? [Building.Academy1, Building.Academy2, Building.ResearchLab] : [Building.PlanetaryInstitute, Building.ResearchLab];
     case Building.ResearchLab: return faction === Faction.Bescods ? [Building.PlanetaryInstitute] : [Building.Academy1, Building.Academy2];

--- a/src/engine.spec.ts
+++ b/src/engine.spec.ts
@@ -184,7 +184,7 @@ describe("Engine", () => {
     expect(engine.players[Player.Player1].data.qics).to.equal(2);
   });
 
-  it ("should allow to place a gaia former", () => {
+  it ("should allow to place a gaia former and next round checks for transformation to gaia planet", () => {
     const moves = parseMoves(`
       init 2 randomSeed
       p1 faction terrans
@@ -193,11 +193,11 @@ describe("Engine", () => {
       p2 build m 4x-2
       p2 build m 2x-2
       p1 build m 4x0
+      p1 build gf 3x1
+      p2 pass
+      p1 pass
     `);
-
-    const engine = new Engine(moves);
-    engine.move("p1 build gf 3x1");
-    expect(() => new Engine(moves)).to.not.throw();
+   expect(() => new Engine(moves)).to.not.throw();
   });
 
   it("should throw when two players choose factions on the same planet", () => {

--- a/src/engine.spec.ts
+++ b/src/engine.spec.ts
@@ -184,6 +184,22 @@ describe("Engine", () => {
     expect(engine.players[Player.Player1].data.qics).to.equal(2);
   });
 
+  it ("should allow to place a gaia former", () => {
+    const moves = parseMoves(`
+      init 2 randomSeed
+      p1 faction terrans
+      p2 faction nevlas
+      p1 build m 2x2
+      p2 build m 4x-2
+      p2 build m 2x-2
+      p1 build m 4x0
+    `);
+
+    const engine = new Engine(moves);
+    engine.move("p1 build gf 3x1");
+    expect(() => new Engine(moves)).to.not.throw();
+  });
+
   it("should throw when two players choose factions on the same planet", () => {
     const moves = ["init 3 seed?2", "p1 faction terrans", "p2 faction lantids"];
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -8,7 +8,8 @@ import {
   Player as PlayerEnum,
   Operator,
   Building,
-  ResearchField
+  ResearchField,
+  Planet
 } from './enums';
 import Event from './events';
 import { CubeCoordinates } from 'hexagrid';
@@ -179,13 +180,30 @@ export default class Engine {
       this.turnOrder = (this.round === 1 || this.round === -1) ? this.players.map((pl, i) => i as PlayerEnum) :
       this.passedPlayers;
       this.passedPlayers = [];
-      for (const player of this.playersInOrder()) {
-        player.receiveIncome();
-      }
     }
 
     this.currentPlayer = this.turnOrder[0];
     this.currentPlayerTurnOrderPos = 0;
+    this.incomePhase();
+    this.gaiaPhase();
+
+  }
+
+  incomePhase(){
+    for (const player of this.playersInOrder()) {
+      player.receiveIncome();
+      //TODO split power actions and request player order
+    }
+  }
+
+  gaiaPhase(){
+    // transform Transdim planets into Gaia if gaiaformed
+    for (const hex of this.map.toJSON()) {
+      if (hex.data.planet === Planet.Transdim  && hex.data.player !== undefined && hex.data.building === Building.GaiaFormer ) {
+        hex.data.planet = Planet.Gaia;
+      }
+    }
+    //TODO manage gaia phase actions for specific factions
   }
 
   /** Next player to make a move, after current player makes their move */

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -32,6 +32,7 @@ export enum Resource {
   VictoryPoint = "vp",
   TerraformStep = "d",
   RangeExtension = "r",
+  GainGaiaFormer = "ggf",
   UpgradeTerraforming = "up-terra",
   UpgradeNavigation = "up-nav",
   UpgradeIntelligence = "up-int",

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -27,6 +27,7 @@ export enum Resource {
   Knowledge = "k",
   Qic = "q",
   ChargePower = "pw",
+  SpendPower = "spw",
   GainToken = "t",
   VictoryPoint = "vp",
   TerraformStep = "d",
@@ -81,7 +82,8 @@ export enum Building {
   ResearchLab = "lab",
   PlanetaryInstitute = "PI",
   Academy1 = "ac1",
-  Academy2 = "ac2"
+  Academy2 = "ac2",
+  GaiaFormer = "gf"
 }
 
 export enum Faction {

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -32,7 +32,7 @@ export enum Resource {
   VictoryPoint = "vp",
   TerraformStep = "d",
   RangeExtension = "r",
-  GainGaiaFormer = "ggf",
+  GaiaFormer = "gf",
   UpgradeTerraforming = "up-terra",
   UpgradeNavigation = "up-nav",
   UpgradeIntelligence = "up-int",

--- a/src/faction-boards/types.ts
+++ b/src/faction-boards/types.ts
@@ -133,8 +133,7 @@ export class FactionBoard {
   }
 
   maxBuildings(building: Building): number {
-    //TODO limit gaiaformers by tech level
-    return building === Building.GaiaFormer ? 3 : this[building].income.length;
+    return this[building].income.length;
   }
 
   cost( targetPlanet: Planet, building: Building, isolated = true): Reward[] {

--- a/src/faction-boards/types.ts
+++ b/src/faction-boards/types.ts
@@ -1,11 +1,12 @@
 import Reward from "../reward";
 import * as _ from "lodash";
 import Event from "../events";
-import { Building } from "../enums";
+import { Building, Planet } from "../enums";
 
 export interface FactionBoardRaw {
   [Building.Mine]?: {
     cost?: string,
+    costGaia?: string;
     income?: string[]
   };
   [Building.TradingStation]?: {
@@ -29,16 +30,22 @@ export interface FactionBoardRaw {
     cost?: string,
     income?: string[]
   };
+  [Building.GaiaFormer]?: {
+    cost?: string,
+    income?: string[]
+  };
   income?: string[];
   power?: {
     bowl1?: number,
     bowl2?: number
   };
+
 }
 
 const defaultBoard: FactionBoardRaw = {
   [Building.Mine]: {
     cost: "2c,o",
+    costGaia: "2c,o,q",
     income: ["+o","+o","~","+o","+o","+o","+o","+o"]
   },
   [Building.TradingStation]: {
@@ -62,6 +69,10 @@ const defaultBoard: FactionBoardRaw = {
     cost: "6c,4o",
     income: ["+4pw,t"]
   },
+  [Building.GaiaFormer]: {
+    cost: "6spw",
+    income: ["~","~","~"]
+  },
   income: ["3k,4o,15c,q", "+o,k"],
   power: {
     bowl1: 4,
@@ -72,6 +83,7 @@ const defaultBoard: FactionBoardRaw = {
 export class FactionBoard {
   [Building.Mine]: {
     cost: Reward[],
+    costGaia: Reward[],
     income: Event[]
   };
   [Building.TradingStation]: {
@@ -92,6 +104,10 @@ export class FactionBoard {
     income: Event[]
   };
   [Building.PlanetaryInstitute]: {
+    cost: Reward[];
+    income: Event[];
+  };
+  [Building.GaiaFormer]: {
     cost: Reward[];
     income: Event[];
   };
@@ -117,14 +133,18 @@ export class FactionBoard {
   }
 
   maxBuildings(building: Building): number {
-    return this[building].income.length;
+    //TODO limit gaiaformers by tech level
+    return building === Building.GaiaFormer ? 3 : this[building].income.length;
   }
 
-  cost(building: Building, isolated = true): Reward[] {
+  cost( targetPlanet: Planet, building: Building, isolated = true): Reward[] {
+    if (building === Building.Mine && targetPlanet === Planet.Gaia) {
+      return this[building].costGaia;
+    }
     if (building === Building.TradingStation && isolated) {
       return this[building].isolatedCost;
     }
-
+    //TODO add terraforming costs
     return this[building].cost;
   }
 }

--- a/src/planets.ts
+++ b/src/planets.ts
@@ -1,0 +1,19 @@
+import { Planet, Faction } from "..";
+
+const planetCycle = [ Planet.Terra, Planet.Oxide, Planet.Volcanic, Planet.Desert, Planet.Swamp, Planet.Titanium, Planet.Ice];
+
+export function terraformingStepsRequired(factionPlanet: Planet, targetPlanet: Planet): number {
+
+    if ( targetPlanet === Planet.Gaia || targetPlanet === Planet.Transdim){ 
+      return 0;
+    }
+
+    let dist = planetCycle.findIndex(pc => pc === targetPlanet) - planetCycle.findIndex(pc => pc === factionPlanet);
+    if (dist > 3) {
+        dist -= 7;
+    } else if (dist < -3) {
+        dist += 7;
+    }
+
+    return Math.abs(dist);
+}

--- a/src/player-data.ts
+++ b/src/player-data.ts
@@ -31,6 +31,7 @@ export default class PlayerData extends EventEmitter {
   [Building.ResearchLab]: number = 0;
   [Building.Academy1]: number = 0;
   [Building.Academy2]: number = 0; 
+  [Building.GaiaFormer]: number = 0; 
   research: {
     [key in ResearchField]: number
   } = {
@@ -123,6 +124,7 @@ export default class PlayerData extends EventEmitter {
       case Resource.VictoryPoint: return this.victoryPoints >= reward.count;
       case Resource.Qic: return this.qics >= reward.count;
       case Resource.None: return true;
+      case Resource.SpendPower: return this.power.bowl1 + this.power.bowl2 + this.power.bowl3 >= reward.count;
     }
 
     return false;

--- a/src/player-data.ts
+++ b/src/player-data.ts
@@ -38,6 +38,7 @@ export default class PlayerData extends EventEmitter {
     terra: 0, nav: 0,int: 0, gaia: 0, eco: 0, sci: 0
   };
   range: number = 1;
+  gainedGaiaformers: number = 0;
   // Coordinates occupied by buildings
   occupied: CubeCoordinates[] = [];
 
@@ -51,6 +52,7 @@ export default class PlayerData extends EventEmitter {
       power: this.power,
       research: this.research,
       range: this.range,
+      gainedGaiaformers: this.gainedGaiaformers,
       occupied: this.occupied
     }
 
@@ -101,6 +103,7 @@ export default class PlayerData extends EventEmitter {
       case Resource.GainToken: this.power.bowl1 += count; return;
       case Resource.ChargePower: this.chargePower(count); return;
       case Resource.RangeExtension: this.range += count; return;
+      case Resource.GainGaiaFormer: this.gainedGaiaformers +=count; return;
       default: break; // Not implemented
     }
   }

--- a/src/player-data.ts
+++ b/src/player-data.ts
@@ -38,7 +38,7 @@ export default class PlayerData extends EventEmitter {
     terra: 0, nav: 0,int: 0, gaia: 0, eco: 0, sci: 0
   };
   range: number = 1;
-  gainedGaiaformers: number = 0;
+  gaiaformers: number = 0;
   // Coordinates occupied by buildings
   occupied: CubeCoordinates[] = [];
 
@@ -52,7 +52,7 @@ export default class PlayerData extends EventEmitter {
       power: this.power,
       research: this.research,
       range: this.range,
-      gainedGaiaformers: this.gainedGaiaformers,
+      gaiaformers: this.gaiaformers,
       occupied: this.occupied
     }
 
@@ -103,7 +103,7 @@ export default class PlayerData extends EventEmitter {
       case Resource.GainToken: this.power.bowl1 += count; return;
       case Resource.ChargePower: this.chargePower(count); return;
       case Resource.RangeExtension: this.range += count; return;
-      case Resource.GainGaiaFormer: this.gainedGaiaformers +=count; return;
+      case Resource.GaiaFormer: this.gaiaformers +=count; return;
       default: break; // Not implemented
     }
   }

--- a/src/player.ts
+++ b/src/player.ts
@@ -52,7 +52,7 @@ export default class Player {
   }
 
   canBuild(targetPlanet: Planet, building: Building, isolated = true) : boolean {
-    if (this.data[building] >= (building === Building.GaiaFormer ? this.data.gainedGaiaformers : this.board.maxBuildings(building))) {
+    if (this.data[building] >= (building === Building.GaiaFormer ? this.data.gaiaformers : this.board.maxBuildings(building))) {
       // Too many buildings of the same kind
       return false;
     }

--- a/src/player.ts
+++ b/src/player.ts
@@ -7,6 +7,7 @@ import factions from './factions';
 import Reward from './reward';
 import { CubeCoordinates } from 'hexagrid';
 import researchTracks from './research-tracks';
+import { terraformingStepsRequired } from './planets';
 
 export default class Player {
   faction: Faction = null;
@@ -50,12 +51,12 @@ export default class Player {
     return factions.planet(this.faction);
   }
 
-  canBuild(building: Building, isolated = true) : boolean {
+  canBuild(targetPlanet: Planet, building: Building, isolated = true) : boolean {
     if (this.data[building] >= this.board.maxBuildings(building)) {
       // Too many buildings of the same kind
       return false;
     }
-    return this.data.canPay(this.board.cost(building, isolated));
+    return this.data.canPay(this.board.cost(targetPlanet, building, isolated));
   }
 
   loadFaction(faction: Faction) {

--- a/src/player.ts
+++ b/src/player.ts
@@ -52,10 +52,11 @@ export default class Player {
   }
 
   canBuild(targetPlanet: Planet, building: Building, isolated = true) : boolean {
-    if (this.data[building] >= this.board.maxBuildings(building)) {
+    if (this.data[building] >= (building === Building.GaiaFormer ? this.data.gainedGaiaformers : this.board.maxBuildings(building))) {
       // Too many buildings of the same kind
       return false;
     }
+  
     return this.data.canPay(this.board.cost(targetPlanet, building, isolated));
   }
 

--- a/src/research-tracks.ts
+++ b/src/research-tracks.ts
@@ -12,7 +12,7 @@ export default {
     [],["q"],["q"],["2q,3pw"],["2q"],["4q"]
   ],
   [ResearchField.GaiaProject]: [
-    [],["ggf"],["3t"],["3pw","ggf"],["ggf"],["4vp", "g > vp"]
+    [],["gf"],["3t"],["3pw","gf"],["gf"],["4vp", "g > vp"]
   ],
   [ResearchField.Economy]: [
     [],["+2c,pw"],["+o,pw"],["+c,pw", "3pw"],["+o,c,pw"],["3o,6c,6pw"]

--- a/src/research-tracks.ts
+++ b/src/research-tracks.ts
@@ -6,16 +6,16 @@ export default {
     [],["2o"],[],["3pw"],["2o"],[]
   ], 
   [ResearchField.Navigation]: [
-    [],["q"],["r"],["q,3pw"],["r"],[]
+    [],["q"],["r"],["q,3pw"],["r"],["r"]
   ],
   [ResearchField.Intelligence]: [
     [],["q"],["q"],["2q,3pw"],["2q"],["4q"]
   ],
   [ResearchField.GaiaProject]: [
-    [],[],[],["3pw"],[],["4vp", "g > vp"]
+    [],[],["3t"],["3pw"],[""],["4vp", "g > vp"]
   ],
   [ResearchField.Economy]: [
-    [],["+2c,pw"],["+o,pw"],["+c,pw", "3pw"],["+o,c,pw"],["+o,2c,2pw"]
+    [],["+2c,pw"],["+o,pw"],["+c,pw", "3pw"],["+o,c,pw"],["3o,6c,6pw"]
   ],
   [ResearchField.Science]: [
     [],["+k"],["+k"],["+k", "3pw"],["+k"],["9k"]

--- a/src/research-tracks.ts
+++ b/src/research-tracks.ts
@@ -12,7 +12,7 @@ export default {
     [],["q"],["q"],["2q,3pw"],["2q"],["4q"]
   ],
   [ResearchField.GaiaProject]: [
-    [],[],["3t"],["3pw"],[""],["4vp", "g > vp"]
+    [],["ggf"],["3t"],["3pw","ggf"],["ggf"],["4vp", "g > vp"]
   ],
   [ResearchField.Economy]: [
     [],["+2c,pw"],["+o,pw"],["+c,pw", "3pw"],["+o,c,pw"],["3o,6c,6pw"]


### PR DESCRIPTION
you can start a gaia project on Transdim planets, and then upgrade to mine. You can now build a mine on gaia planets.

Still missing:
1. DONE increment available gaia formers based on gaia project tech, 
1a. and decrease cost
2. implement spend power on gaia forming, because it cannot be automatic (i.e. player has to decide where to spend power from)
3.DONE:  implement gaia phase beginning of new round, which turns transdim with gaia former into gaia planets
4. add terraforming cost to canPay
