### PR TITLE
Round boosters

### DIFF
--- a/src/available-command.ts
+++ b/src/available-command.ts
@@ -75,25 +75,25 @@ export function generate(engine: Engine): AvailableCommand[] {
       const board = engine.player(player).board;
       const grid = engine.map.grid;
    
-      // initial roundbooster setup or pass sub action
-      if (!data.roundBooster || engine.round === Round.SetupRoundBooster) {
-        for (const booster of Object.values(Booster)) {
+      for (const booster of Object.values(Booster)) {
           if (engine.roundBoosters[booster]) {
             boosters.push({
               booster
             });
           }    
+      }
+
+      commands.push(
+        {
+          name: engine.round === Round.SetupRoundBooster ? Command.ChooseRoundBooster : Command.Pass,
+          player,
+          data: { boosters }
         }
+      )
 
-        return [
-          {
-            name: Command.ChooseRoundBooster,
-            player,
-            data: { boosters }
-          }
-        ];
-      };
-
+      if (engine.round === Round.SetupRoundBooster) {
+        return commands;
+      } 
 
       // Add building moves
       {
@@ -199,12 +199,6 @@ export function generate(engine: Engine): AvailableCommand[] {
           });
         }
       }
-
-      // Give the player the ability to pass
-      commands.push({
-        name: Command.Pass,
-        player
-      });
 
       return commands;
     }

--- a/src/available-command.ts
+++ b/src/available-command.ts
@@ -1,4 +1,4 @@
-import { Command, Faction, Building, ResearchField, Planet } from './enums';
+import { Command, Faction, Building, ResearchField, Planet, Round, Booster } from './enums';
 import Engine from './engine';
 import * as _ from 'lodash';
 import factions from './factions';
@@ -17,173 +17,196 @@ export default interface AvailableCommand {
 }
 
 export function generate(engine: Engine): AvailableCommand[] {
-  // init game
-  if (engine.round == -2) {
-    return [{ name: Command.Init }];
-  }
-  // faction selection
-  if (engine.round == -1 ) {
-    return [
-      {
-        name: Command.ChooseFaction,
-        player: engine.currentPlayer,
-        data: _.difference(
-          Object.values(Faction),
-          engine.players.map(pl => pl.faction),
-          engine.players.map(pl => factions.opposite(pl.faction))
-        )
+
+  switch ( engine.round ) {
+    case Round.Init: {
+      return [{ name: Command.Init }];
+    };
+    case Round.SetupFaction: {
+      return [
+        {
+          name: Command.ChooseFaction,
+          player: engine.currentPlayer,
+          data: _.difference(
+            Object.values(Faction),
+            engine.players.map(pl => pl.faction),
+            engine.players.map(pl => factions.opposite(pl.faction))
+          )
+        }
+      ];
+    };
+    case Round.SetupBuilding: {
+      const player = engine.currentPlayer;
+      const planet = engine.player(player).planet;
+      const buildings = [];
+
+      for (const hex of engine.map.toJSON()) {
+        if (hex.data.planet === planet && !hex.data.building) {
+          buildings.push({
+            building:
+              engine.player(player).faction !== Faction.Ivits
+                ? Building.Mine
+                : Building.PlanetaryInstitute,
+            coordinates: hex.toString(),
+            cost: '~'
+          });
+        }
       }
-    ];
-  }
 
-  // initial buuildings
-  if (engine.round == 0) {
-    const player = engine.currentPlayer;
-    const planet = engine.player(player).planet;
-    const buildings = [];
+      return [
+        {
+          name: Command.Build,
+          player,
+          data: { buildings }
+        }
+      ];
+    };
 
-    for (const hex of engine.map.toJSON()) {
-      if (hex.data.planet === planet && !hex.data.building) {
-        buildings.push({
-          building:
-            engine.player(player).faction !== Faction.Ivits
-              ? Building.Mine
-              : Building.PlanetaryInstitute,
-          coordinates: hex.toString(),
-          cost: '~'
-        });
-      }
-    }
+    case Round.SetupRoundBooster: 
+    default : {
+      // We are in a regular round
+      const commands = [];
+      const boosters = [];
+      const player = engine.currentPlayer;
 
-    return [
-      {
-        name: Command.Build,
-        player,
-        data: { buildings }
-      }
-    ];
-  }
+      assert(player !== undefined, "Problem with the engine, player to play is unknown");
 
-  // We are in a regular round
-  const commands = [];
-  const player = engine.currentPlayer;
-
-  assert(player !== undefined, "Problem with the engine, player to play is unknown");
-
-  const data = engine.player(player).data;
-  const board = engine.player(player).board;
-  const grid = engine.map.grid;
-
-  // Add building moves
-  {
-    const planet = engine.player(player).planet;
-    const buildings = [];
-
-    for (const hex of engine.map.toJSON()) {
-      // exclude empty planets and other players' planets
-      if (( hex.data.planet === Planet.Empty  ) || (hex.data.player !== undefined && hex.data.player !== player)) {
-        continue;
-      }
-      //upgrade existing player's building
-      if (hex.data.building ) {
-
-        //excluding Transdim planet until transformed into Gaia planets
-        if (hex.data.planet === Planet.Transdim){
-          continue
+      const data = engine.player(player).data;
+      const board = engine.player(player).board;
+      const grid = engine.map.grid;
+   
+      // initial roundbooster setup or pass sub action
+      if (!data.roundBooster || engine.round === Round.SetupRoundBooster) {
+        for (const booster of Object.values(Booster)) {
+          if (engine.roundBoosters[booster]) {
+            boosters.push({
+              booster
+            });
+          }    
         }
 
-        const isolated = (() => {
-          // We only care about mines that can transform into trading stations;
-          if(hex.data.building !== Building.Mine) {
-            return true;
+        return [
+          {
+            name: Command.ChooseRoundBooster,
+            player,
+            data: { boosters }
           }
+        ];
+      };
 
-          // Check each other player to see if there's a building in range
-          for (const pl of engine.players) {
-            if (pl !== engine.player(player)) {
-              for (const loc of pl.data.occupied) {
-                if (grid.distance(loc.q, loc.r, hex.q, hex.r) < ISOLATED_DISTANCE) {
-                  return false;
+
+      // Add building moves
+      {
+        const planet = engine.player(player).planet;
+        const buildings = [];
+
+        for (const hex of engine.map.toJSON()) {
+          // exclude empty planets and other players' planets
+          if (( hex.data.planet === Planet.Empty  ) || (hex.data.player !== undefined && hex.data.player !== player)) {
+            continue;
+          }
+          //upgrade existing player's building
+          if (hex.data.building ) {
+
+            //excluding Transdim planet until transformed into Gaia planets
+            if (hex.data.planet === Planet.Transdim){
+              continue
+            }
+
+            const isolated = (() => {
+              // We only care about mines that can transform into trading stations;
+              if(hex.data.building !== Building.Mine) {
+                return true;
+              }
+
+              // Check each other player to see if there's a building in range
+              for (const pl of engine.players) {
+                if (pl !== engine.player(player)) {
+                  for (const loc of pl.data.occupied) {
+                    if (grid.distance(loc.q, loc.r, hex.q, hex.r) < ISOLATED_DISTANCE) {
+                      return false;
+                    }
+                  }
                 }
               }
+
+              return true;
+            })();
+
+            const upgraded = upgradedBuildings(hex.data.building, engine.player(player).faction);
+
+            for (const upgrade of upgraded) {
+              var buildCost = engine.player(player).canBuild(hex.data.planet, upgrade, isolated);
+              if ( buildCost !== undefined) {
+                buildings.push({
+                  upgradedBuilding: hex.data.building,
+                  building: upgrade,
+                  cost: buildCost.map(c => c.toString()).join(','),
+                  coordinates: hex.toString()
+                });
+              }
             }
-          }
+          } else {
+            // planet without building
+            // Check if the range is enough to access the planet
+            const inRange = data.occupied.some(loc => grid.distance(hex.q, hex.r, loc.q, loc.r) <= data.range);
 
-          return true;
-        })();
+            if (!inRange) {
+              continue;
+            }
 
-        const upgraded = upgradedBuildings(hex.data.building, engine.player(player).faction);
+            const building = hex.data.planet === Planet.Transdim ? Building.GaiaFormer : Building.Mine  ;
+            const buildCost = engine.player(player).canBuild( hex.data.planet, building, false);
+            if ( buildCost !== undefined ){
+                buildings.push({
+                building: building,
+                coordinates: hex.toString(),
+                cost: buildCost.map(c => c.toString()).join(',')
+              });   
+            }         
+            
+          } 
+        } //end for hex
 
-        for (const upgrade of upgraded) {
-          var buildCost = engine.player(player).canBuild(hex.data.planet, upgrade, isolated);
-          if ( buildCost !== undefined) {
-            buildings.push({
-              upgradedBuilding: hex.data.building,
-              building: upgrade,
-              cost: buildCost.map(c => c.toString()).join(','),
-              coordinates: hex.toString()
+        if (buildings.length > 0) {
+        commands.push({
+          name: Command.Build,
+          player,
+          data: { buildings }
+        });
+        }
+      } // end add buildings
+
+      // Upgrade research
+      if (data.canPay(Reward.parse(UPGRADE_RESEARCH_COST))) {
+        const tracks = [];
+
+        for (const field of Object.values(ResearchField)) {
+          if (data.research[field] < research.lastTile(field) && !research.keyNeeded(field, data.research[field] + 1)) {
+            tracks.push({
+              field,
+              to: data.research[field] + 1,
+              cost: UPGRADE_RESEARCH_COST
             });
           }
         }
-      } else {
-        // planet without building
-        // Check if the range is enough to access the planet
-        const inRange = data.occupied.some(loc => grid.distance(hex.q, hex.r, loc.q, loc.r) <= data.range);
 
-        if (!inRange) {
-          continue;
+        if (tracks.length > 0) {
+          commands.push({
+            name: Command.UpgradeResearch,
+            player,
+            data: { tracks }
+          });
         }
-
-        const building = hex.data.planet === Planet.Transdim ? Building.GaiaFormer : Building.Mine  ;
-        const buildCost = engine.player(player).canBuild( hex.data.planet, building, false);
-        if ( buildCost !== undefined ){
-            buildings.push({
-            building: building,
-            coordinates: hex.toString(),
-            cost: buildCost.map(c => c.toString()).join(',')
-          });   
-        }         
-         
-      } 
-    } //end for hex
-
-    if (buildings.length > 0) {
-    commands.push({
-      name: Command.Build,
-      player,
-      data: { buildings }
-    });
-    }
-  } // end add buildings
-
-  // Upgrade research
-  if (data.canPay(Reward.parse(UPGRADE_RESEARCH_COST))) {
-    const tracks = [];
-
-    for (const field of Object.values(ResearchField)) {
-      if (data.research[field] < research.lastTile(field) && !research.keyNeeded(field, data.research[field] + 1)) {
-        tracks.push({
-          field,
-          to: data.research[field] + 1,
-          cost: UPGRADE_RESEARCH_COST
-        });
       }
-    }
 
-    if (tracks.length > 0) {
+      // Give the player the ability to pass
       commands.push({
-        name: Command.UpgradeResearch,
-        player,
-        data: { tracks }
+        name: Command.Pass,
+        player
       });
+
+      return commands;
     }
   }
-
-  // Give the player the ability to pass
-  commands.push({
-    name: Command.Pass,
-    player
-  });
-
-  return commands;
 }

--- a/src/engine.spec.ts
+++ b/src/engine.spec.ts
@@ -67,7 +67,7 @@ describe("Engine", () => {
       p1 build m 4x0
       p2 booster booster1
       p1 booster booster2
-      p1 pass
+      p1 pass booster3
     `);
 
     expect(() => new Engine(moves)).to.not.throw();
@@ -84,7 +84,7 @@ describe("Engine", () => {
       p1 build m 4x0
       p2 booster booster1
       p1 booster booster2
-      p1 pass
+      p1 pass booster3
     `);
 
     expect(() => new Engine(moves)).to.not.throw();
@@ -92,35 +92,35 @@ describe("Engine", () => {
   
   it("should check wrong player order", () => {
     const moves = parseMoves(`
-    init 2 randomSeed
-    p1 faction terrans
-    p2 faction nevlas
-    p1 build m 4x0
-    p2 build m 4x-2
-    p2 build m -4x3
-    p1 build m -7x2
-    p2 booster booster1
-    p1 booster booster2
-    p1 build ts 4x0
-    p2 build ts -4x3
-    p2 pass
+      init 2 randomSeed
+      p1 faction terrans
+      p2 faction nevlas
+      p1 build m 4x0
+      p2 build m 4x-2
+      p2 build m -4x3
+      p1 build m -7x2
+      p2 booster booster1
+      p1 booster booster2
+      p1 build ts 4x0
+      p2 build ts -4x3
+      p2 pass booster3
     `);
     expect(() => new Engine(moves)).to.throw(AssertionError);
   })
 
   it("should allow players to upgrade a mine to a TS, either isolated or not", () => {
     const moves = parseMoves(`
-    init 2 randomSeed
-    p1 faction terrans
-    p2 faction nevlas
-    p1 build m 4x0
-    p2 build m 4x-2
-    p2 build m -4x3
-    p1 build m -7x2
-    p2 booster booster1
-    p1 booster booster2
-    p1 build ts 4x0
-    p2 build ts -4x3  
+      init 2 randomSeed
+      p1 faction terrans
+      p2 faction nevlas
+      p1 build m 4x0
+      p2 build m 4x-2
+      p2 build m -4x3
+      p1 build m -7x2
+      p2 booster booster1
+      p1 booster booster2
+      p1 build ts 4x0
+      p2 build ts -4x3  
     `);
 
     expect(() => new Engine(moves)).to.not.throw();
@@ -163,10 +163,9 @@ describe("Engine", () => {
       p2 booster booster1
       p1 booster booster2
       p1 build ts 2x2
-      p2 pass
-      p2 booster booster4
+      p2 pass booster4
       p1 build ts 4x0
-      p1 pass
+      p1 pass booster1
     `);
 
     expect(() => new Engine(moves)).to.not.throw();
@@ -227,10 +226,8 @@ describe("Engine", () => {
       p2 booster booster1
       p1 booster booster2
       p1 build gf 3x1
-      p2 pass
-      p2 booster booster4
-      p1 pass
-      p1 booster booster1
+      p2 pass booster4
+      p1 pass booster1
       p2 build ts 4x-2
       p1 build m 3x1
     `);

--- a/src/engine.spec.ts
+++ b/src/engine.spec.ts
@@ -55,8 +55,23 @@ describe("Engine", () => {
 
     expect(() => new Engine(moves)).to.not.throw();
   });
+ 
+  it("should allow to select round boosters  without errors", () => {
+    const moves = parseMoves(`
+      init 2 randomSeed
+      p1 faction lantids
+      p2 faction gleens
+      p1 build m 2x2
+      p2 build m 0x3
+      p2 build m 3x0
+      p1 build m 4x0
+      p2 booster booster1
+      p1 booster booster2
+      p1 pass
+    `);
 
-
+    expect(() => new Engine(moves)).to.not.throw();
+  });
 
   it("should allow players to pass", () => {
     const moves = parseMoves(`
@@ -67,6 +82,8 @@ describe("Engine", () => {
       p2 build m 0x3
       p2 build m 3x0
       p1 build m 4x0
+      p2 booster booster1
+      p1 booster booster2
       p1 pass
     `);
 
@@ -82,6 +99,8 @@ describe("Engine", () => {
     p2 build m 4x-2
     p2 build m -4x3
     p1 build m -7x2
+    p2 booster booster1
+    p1 booster booster2
     p1 build ts 4x0
     p2 build ts -4x3
     p2 pass
@@ -98,6 +117,8 @@ describe("Engine", () => {
     p2 build m 4x-2
     p2 build m -4x3
     p1 build m -7x2
+    p2 booster booster1
+    p1 booster booster2
     p1 build ts 4x0
     p2 build ts -4x3  
     `);
@@ -118,6 +139,8 @@ describe("Engine", () => {
       p2 build m 0x3
       p2 build m 3x0
       p1 build m 2x2
+      p2 booster booster1
+      p1 booster booster2
       p1 build ts 2x2
       p2 build ts 0x3
       p1 build PI 2x2
@@ -137,8 +160,11 @@ describe("Engine", () => {
       p2 build m 0x3
       p2 build m 3x0
       p1 build m 4x0
+      p2 booster booster1
+      p1 booster booster2
       p1 build ts 2x2
       p2 pass
+      p2 booster booster4
       p1 build ts 4x0
       p1 pass
     `);
@@ -155,6 +181,8 @@ describe("Engine", () => {
       p2 build m 0x3
       p2 build m 3x0
       p1 build m 4x0
+      p2 booster booster1
+      p1 booster booster2
       p1 build m -7x2
     `);
 
@@ -173,6 +201,9 @@ describe("Engine", () => {
       p3 build m 1x-1
       p2 build m -5x4
       p1 build m 2x2
+      p3 booster booster1
+      p2 booster booster2
+      p1 booster booster4
     `);
 
     const engine = new Engine(moves);
@@ -184,7 +215,7 @@ describe("Engine", () => {
     expect(engine.players[Player.Player1].data.qics).to.equal(2);
   });
 
-  it ("should allow to place a gaia former and next round checks for transformation to gaia planet", () => {
+  it ("should allow to place a gaia former and next round checks for transformation to gaia planet, pass is checking booster availablity", () => {
     const moves = parseMoves(`
       init 2 randomSeed
       p1 faction terrans
@@ -193,9 +224,13 @@ describe("Engine", () => {
       p2 build m 4x-2
       p2 build m 2x-2
       p1 build m 4x0
+      p2 booster booster1
+      p1 booster booster2
       p1 build gf 3x1
       p2 pass
+      p2 booster booster4
       p1 pass
+      p1 booster booster1
       p2 build ts 4x-2
       p1 build m 3x1
     `);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -221,7 +221,7 @@ export default class Engine {
 
   /** Next player to make a move, after current player makes their move */
   moveToNextPlayer(command : Command): PlayerEnum {
-    if ( command === Command.ChooseRoundBooster || this.round === Round.SetupFaction || this.round === Round.SetupBuilding ) {
+    if ( command === Command.Pass || this.round === Round.SetupFaction || this.round === Round.SetupBuilding || this.round === Round.SetupRoundBooster) {
         // happens in round SetupROundBooster and standard rounds after pass move
         const playerPos = this.currentPlayerTurnOrderPos;
         this.passedPlayers.push(this.currentPlayer);
@@ -231,8 +231,7 @@ export default class Engine {
         this.currentPlayer = this.turnOrder[newPlayerPos];  
         this.currentPlayerTurnOrderPos = newPlayerPos;
 
-    } else if ( command !== Command.Pass) {
-        // Command.PAss stays with the current player
+    } else {
         const next = (this.currentPlayerTurnOrderPos + 1) % this.turnOrder.length;
         this.currentPlayerTurnOrderPos = next;
         this.currentPlayer = this.turnOrder[next];
@@ -272,8 +271,8 @@ export default class Engine {
     this.players[player].loadFaction(faction as Faction);
   }
 
-  [Command.ChooseRoundBooster](player: PlayerEnum, booster: Booster) {
-    const { boosters } = this.availableCommand(player, Command.ChooseRoundBooster).data;
+  [Command.ChooseRoundBooster](player: PlayerEnum, booster: Booster, fromCommand: Command = Command.ChooseRoundBooster ) {
+    const { boosters } = this.availableCommand(player, fromCommand).data;
     const boost = boosters.find(boo => boo.booster === booster);
 
     assert(boost,
@@ -320,8 +319,9 @@ export default class Engine {
     this.player(player).data.gainReward(new Reward(`${Command.UpgradeResearch}-${field}`));
   }
 
-  [Command.Pass](player: PlayerEnum) {
+  [Command.Pass](player: PlayerEnum, booster: Booster) {
     this.roundBoosters[this.players[player].data.roundBooster] = true;
     this.players[player].pass();
+    (this[Command.ChooseRoundBooster] as any)(player, booster, Command.Pass);
   }
 }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -26,12 +26,7 @@ export default class Engine {
     [key in Booster]: boolean 
   }  = { booster1: true ,  booster2: true,  booster3: true, booster4: true, booster5: true, booster6: true, booster7: true, booster8: true, booster9: true, booster10: true  }; 
   availableCommands: AvailableCommand[] = [];
-<<<<<<< HEAD
   round: number = Round.Init;
-  turn: number = 0;
-=======
-  round: number = -2;
->>>>>>> b40c19a4186ed30b3464116b266dfae8bc524f1b
   /** Order of players in the turn */
   turnOrder: PlayerEnum[] = [];
   /**

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -9,7 +9,9 @@ import {
   Operator,
   Building,
   ResearchField,
-  Planet
+  Planet,
+  Round,
+  Booster
 } from './enums';
 import Event from './events';
 import { CubeCoordinates } from 'hexagrid';
@@ -17,14 +19,19 @@ import { CubeCoordinates } from 'hexagrid';
 import AvailableCommand, {
   generate as generateAvailableCommands
 } from './available-command';
-import factions from './factions';
 import Reward from './reward';
+import boosts from './tiles/boosters';
+import { SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION } from 'constants';
+
 
 export default class Engine {
   map: SpaceMap;
   players: Player[];
+  roundBoosters:  {
+    [key in Booster]: boolean 
+  }  = { booster1: true ,  booster2: true,  booster3: true, booster4: true, booster5: true, booster6: true, booster7: true, booster8: true, booster9: true, booster10: true  }; 
   availableCommands: AvailableCommand[] = [];
-  round: number = -2;
+  round: number = Round.Init;
   turn: number = 0;
   /** Order of players in the turn */
   turnOrder: PlayerEnum[] = [];
@@ -75,7 +82,7 @@ export default class Engine {
   move(move: string) {
     const split = move.trim().split(' ');
 
-    if (this.round === -2) {
+    if (this.round === Round.Init) {
       const command = split[0] as Command;
 
       const available = this.availableCommands;
@@ -83,7 +90,7 @@ export default class Engine {
 
       assert(
         commandNames.includes(command),
-        'Available commands: ' + commandNames.join(', ')
+        'Move ' + move + ' not in Available commands: ' + commandNames.join(', ')
       );
 
       (this[command] as any)(...split.slice(1));
@@ -106,22 +113,19 @@ export default class Engine {
 
       assert(
         this.availableCommand(player, command),
-        'Available commands: ' + commandNames.join(', ')
+        'Move ' + move + ' not in Available commands: ' + commandNames.join(', ')
       );
 
       (this[command] as any)(player as PlayerEnum, ...split.slice(2));
 
+      // Let the next player move based on the command
+      this.moveToNextPlayer(command);
+
       if (this.turnOrder.length === 0) {
         // If all players have passed
         this.endRound();
-      } else {
-        // Let the next player move
-        this.moveToNextPlayer();
-        if (this.currentPlayer === undefined) {
-          this.endRound();
-        }
       }
-    }
+    } 
   }
 
   numberOfPlayersWithFactions(): number {
@@ -140,8 +144,7 @@ export default class Engine {
     return engine;
   }
 
-  endRound() {
-  
+  endRound() { 
     if ( this.round < 6 ) {
       this.beginRound();
 
@@ -153,34 +156,46 @@ export default class Engine {
 
   beginRound() {
     this.round += 1;
-    if (this.round === 0) {
-      // Setup round - add Ivits to the end, before third Xenos
-      const setupTurnOrder = this.players
-        .filter(pl => pl.faction !== Faction.Ivits)
-        .map((pl, i) => i as PlayerEnum);
-      const reverseSetupTurnOrder = setupTurnOrder.slice().reverse();
-      this.turnOrder = setupTurnOrder.concat(reverseSetupTurnOrder);
 
-      const posXenos = this.players.findIndex(
-        pl => pl.faction === Faction.Xenos
-      );
-      if (posXenos !== -1) {
-        this.turnOrder.push(posXenos as PlayerEnum);
-      }
+    switch (this.round) {
+      case Round.SetupBuilding: {
+        // Setup round - add Ivits to the end, before third Xenos
+        const setupTurnOrder = this.players
+          .filter(pl => pl.faction !== Faction.Ivits)
+          .map((pl, i) => i as PlayerEnum);
+        const reverseSetupTurnOrder = setupTurnOrder.slice().reverse();
+        this.turnOrder = setupTurnOrder.concat(reverseSetupTurnOrder);
 
-      const posIvits = this.players.findIndex(
-        pl => pl.faction === Faction.Ivits
-      );
-      if (posIvits !== -1) {
-        this.turnOrder.push(posIvits as PlayerEnum);
-      }
-    } else {
-      // The players play in the order in which they passed or 
-      // First round or faction selection the players are in regular order
-      this.turnOrder = (this.round === 1 || this.round === -1) ? this.players.map((pl, i) => i as PlayerEnum) :
-      this.passedPlayers;
-      this.passedPlayers = [];
-    }
+        const posXenos = this.players.findIndex(
+          pl => pl.faction === Faction.Xenos
+        );
+        if (posXenos !== -1) {
+          this.turnOrder.push(posXenos as PlayerEnum);
+        }
+
+        const posIvits = this.players.findIndex(
+          pl => pl.faction === Faction.Ivits
+        );
+        if (posIvits !== -1) {
+          this.turnOrder.push(posIvits as PlayerEnum);
+        }
+        break;
+      };
+      case Round.SetupFaction:
+      case Round.Round1: {
+        this.turnOrder = this.players.map((pl, i) => i as PlayerEnum);
+        this.passedPlayers = [];
+        break;
+      };
+      case Round.SetupRoundBooster:{
+        this.turnOrder = this.players.map((pl, i) => i as PlayerEnum).reverse();
+        break;
+      };
+      default: {
+        // The players play in the order in which they passed or 
+        this.turnOrder = this.passedPlayers;
+      };
+    };
 
     this.currentPlayer = this.turnOrder[0];
     this.currentPlayerTurnOrderPos = 0;
@@ -190,7 +205,7 @@ export default class Engine {
       this.gaiaPhase();
     };
 
-  }
+  };
 
   incomePhase(){
     for (const player of this.playersInOrder()) {
@@ -210,22 +225,26 @@ export default class Engine {
   }
 
   /** Next player to make a move, after current player makes their move */
-  moveToNextPlayer(): PlayerEnum {
-    if (
-      this.round <= 0 &&
-      this.currentPlayerTurnOrderPos + 1 === this.turnOrder.length
-    ) {
-      // all players played a one round only turn (faction selection and initial buildings)
-      this.currentPlayerTurnOrderPos = undefined;
-      this.currentPlayer = undefined;
-      return;
-    } else {
-      const next = (this.currentPlayerTurnOrderPos + 1) % this.turnOrder.length;
-      this.currentPlayerTurnOrderPos = next;
-      this.currentPlayer = this.turnOrder[next];
-      return;
-    }
+  moveToNextPlayer(command : Command): PlayerEnum {
+    if ( command === Command.ChooseRoundBooster || this.round === Round.SetupFaction || this.round === Round.SetupBuilding ) {
+        // happens in round SetupROundBooster and standard rounds after pass move
+        const playerPos = this.currentPlayerTurnOrderPos;
+        this.passedPlayers.push(this.currentPlayer);
+        this.turnOrder.splice( playerPos, 1); 
+        // if latest player is passing
+        const newPlayerPos = playerPos + 1 > this.turnOrder.length ? 0 : playerPos;
+        this.currentPlayer = this.turnOrder[newPlayerPos];  
+        this.currentPlayerTurnOrderPos = newPlayerPos;
+
+    } else if ( command !== Command.Pass) {
+        // Command.PAss stays with the current player
+        const next = (this.currentPlayerTurnOrderPos + 1) % this.turnOrder.length;
+        this.currentPlayerTurnOrderPos = next;
+        this.currentPlayer = this.turnOrder[next];
+        return;
+      } 
   }
+  
 
   playersInOrder(): Player[] {
     return this.turnOrder.map(i => this.players[i]);
@@ -237,6 +256,8 @@ export default class Engine {
     seed = seed || 'defaultSeed';
 
     this.map = new SpaceMap(nbPlayers, seed);
+
+    // TODO remove 10- ( players + 3) boosters 
 
     this.players = [];
 
@@ -254,6 +275,18 @@ export default class Engine {
     );
 
     this.players[player].loadFaction(faction as Faction);
+  }
+
+  [Command.ChooseRoundBooster](player: PlayerEnum, booster: Booster) {
+    const { boosters } = this.availableCommand(player, Command.ChooseRoundBooster).data;
+    const boost = boosters.find(boo => boo.booster === booster);
+
+    assert(boost,
+      `${booster} is not in the available boosters`
+    );
+    
+    this.roundBoosters[booster] = false;
+    this.players[player].getRoundBooster(booster);
   }
 
   [Command.Build](player: PlayerEnum, building: Building, location: string) {
@@ -293,7 +326,7 @@ export default class Engine {
   }
 
   [Command.Pass](player: PlayerEnum) {
-    this.passedPlayers.push(player);
-    this.turnOrder.splice(this.currentPlayerTurnOrderPos, 1);
+    this.roundBoosters[this.players[player].data.roundBooster] = true;
+    this.players[player].pass();
   }
 }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6,23 +6,18 @@ import {
   Faction,
   Command,
   Player as PlayerEnum,
-  Operator,
   Building,
   ResearchField,
   Planet,
   Round,
   Booster
 } from './enums';
-import Event from './events';
 import { CubeCoordinates } from 'hexagrid';
 
 import AvailableCommand, {
   generate as generateAvailableCommands
 } from './available-command';
 import Reward from './reward';
-import boosts from './tiles/boosters';
-import { SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION } from 'constants';
-
 
 export default class Engine {
   map: SpaceMap;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -184,8 +184,11 @@ export default class Engine {
 
     this.currentPlayer = this.turnOrder[0];
     this.currentPlayerTurnOrderPos = 0;
-    this.incomePhase();
-    this.gaiaPhase();
+    
+    if ( this.round >= 1) {
+      this.incomePhase();
+      this.gaiaPhase();
+    };
 
   }
 

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -107,6 +107,7 @@ export enum Faction {
 export enum Command {
   Init = "init",
   ChooseFaction = "faction",
+  ChooseRoundBooster = "booster",
   Build = "build",
   Pass = "pass",
   UpgradeResearch = "up",
@@ -122,4 +123,30 @@ export enum Player {
   Player3,
   Player4,
   Player5
+}
+
+export enum Round {
+  Init = -3,
+  SetupFaction=-2,
+  SetupBuilding=-1,
+  SetupRoundBooster=0,
+  Round1=1,
+  Round2=2,
+  Round3=3,
+  Round4=4,
+  Round5=5,
+  Round6=6
+}
+
+export enum Booster {
+  Booster1= "booster1",
+  Booster2= "booster2",
+  Booster3= "booster3",
+  Booster4= "booster4",
+  Booster5= "booster5",
+  Booster6= "booster6",
+  Booster7= "booster7",
+  Booster8= "booster8",
+  Booster9= "booster9",
+  Booster10= "booster10"
 }

--- a/src/player-data.ts
+++ b/src/player-data.ts
@@ -1,6 +1,6 @@
 import Reward from "./reward";
 import { Resource } from "..";
-import { ResearchField, Building } from "./enums";
+import { ResearchField, Building, Booster } from "./enums";
 import { EventEmitter } from "eventemitter3";
 import { CubeCoordinates } from "hexagrid";
 
@@ -40,6 +40,7 @@ export default class PlayerData extends EventEmitter {
   range: number = 1;
   gaiaformers: number = 0;
   terraformSteps: number = 0;
+  roundBooster: Booster;
 
   // Coordinates occupied by buildings
   occupied: CubeCoordinates[] = [];
@@ -56,6 +57,7 @@ export default class PlayerData extends EventEmitter {
       range: this.range,
       gaiaformers: this.gaiaformers,
       terraformSteps: this.terraformSteps,
+      roundBooster: this.roundBooster,
       occupied: this.occupied
     }
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -1,4 +1,4 @@
-import { Faction, Operator, ResearchField, Planet, Building, Resource } from './enums';
+import { Faction, Operator, ResearchField, Planet, Building, Resource, Booster } from './enums';
 import PlayerData from './player-data';
 import Event from './events';
 import { factionBoard, FactionBoard } from './faction-boards';
@@ -8,6 +8,7 @@ import Reward from './reward';
 import { CubeCoordinates } from 'hexagrid';
 import researchTracks from './research-tracks';
 import { terraformingStepsRequired } from './planets';
+import boosts from './tiles/boosters';
 
 const TERRAFORMING_COST = 3;
 
@@ -104,6 +105,12 @@ export default class Player {
     }
   }
 
+  removeEvents(events: Event[]) {
+    for (const event of events) {
+      this.removeEvent(event);
+    }  
+  }
+
   removeEvent(event: Event) {
     let findEvent = this.events[event.operator].findIndex(
       ev => ev.toJSON === event.toJSON
@@ -132,8 +139,28 @@ export default class Player {
     }
   }
 
+  pass(){
+    this.receivePassIncome();
+    // remove the old booster  
+    this.removeEvents( Event.parse( boosts[this.data.roundBooster]));
+    this.data.roundBooster =  undefined;
+  }
+
+  getRoundBooster(roundBooster: Booster){  
+    // add the booster to the the player
+    this.data.roundBooster =  roundBooster;
+    this.loadEvents( Event.parse( boosts[roundBooster]));
+  }
+
   receiveIncome() {
     for (const event of this.events[Operator.Income]) {
+      this.data.gainRewards(event.rewards);
+    }
+  }
+
+  receivePassIncome() {
+    // this is for pass tile income (e.g. rounboosters, adv tiles)
+    for (const event of this.events[Operator.Pass]) {
       this.data.gainRewards(event.rewards);
     }
   }

--- a/src/player.ts
+++ b/src/player.ts
@@ -158,13 +158,13 @@ export default class Player {
     }
   }
 
-<<<<<<< HEAD
   receivePassIncome() {
     // this is for pass tile income (e.g. rounboosters, adv tiles)
     for (const event of this.events[Operator.Pass]) {
       this.data.gainRewards(event.rewards);
     }
-=======
+  }
+
   gaiaPhase() {
     /* Move gaia power tokens to regular power bowls */
     // Terrans move directly to power bowl 2
@@ -174,6 +174,5 @@ export default class Player {
       this.data.power.bowl1 += this.data.power.gaia;
     }
     this.data.power.gaia = 0;
->>>>>>> b40c19a4186ed30b3464116b266dfae8bc524f1b
   }
 }

--- a/src/tiles/boosters.ts
+++ b/src/tiles/boosters.ts
@@ -1,13 +1,14 @@
-const BOOSTER1 = ["k,o"];
-const BOOSTER2 = ["o,2t"];
-const BOOSTER3 = ["q,2c"];
-const BOOSTER4 = ["2c", "=> d"];
-const BOOSTER5 = ["2pw", "=> 3r"];
-const BOOSTER6 = ["o", "m | vp"];
-const BOOSTER7 = ["o", "ts | 2vp"];
-const BOOSTER8 = ["k", "lab | 3vp"];
-const BOOSTER9 = ["4pw", "PA | 4vp"];
-const BOOSTER10 = ["4c", "g | vp"];
-const boosters = [BOOSTER1, BOOSTER2, BOOSTER3, BOOSTER4, BOOSTER5, BOOSTER6, BOOSTER7, BOOSTER8, BOOSTER9, BOOSTER10];
+import { Booster } from "../enums";
 
-export default boosters;
+export default  {
+[Booster.Booster1]: ["k,o"],
+[Booster.Booster2]: ["o,2t"],
+[Booster.Booster3]: ["q,2c"],
+[Booster.Booster4]: ["2c", "=> d"],
+[Booster.Booster5]: ["2pw", "=> 3r"],
+[Booster.Booster6]: ["o", "m | vp"],
+[Booster.Booster7]: ["o", "ts | 2vp"],
+[Booster.Booster8]: ["k", "lab | 3vp"],
+[Booster.Booster9]: ["4pw", "PA | 4vp"],
+[Booster.Booster10]: ["4c", "g | vp"]
+};

--- a/src/tiles/boosters.ts
+++ b/src/tiles/boosters.ts
@@ -1,14 +1,14 @@
 import { Booster } from "../enums";
 
 export default  {
-[Booster.Booster1]: ["k,o"],
-[Booster.Booster2]: ["o,2t"],
-[Booster.Booster3]: ["q,2c"],
-[Booster.Booster4]: ["2c", "=> d"],
-[Booster.Booster5]: ["2pw", "=> 3r"],
-[Booster.Booster6]: ["o", "m | vp"],
-[Booster.Booster7]: ["o", "ts | 2vp"],
-[Booster.Booster8]: ["k", "lab | 3vp"],
-[Booster.Booster9]: ["4pw", "PA | 4vp"],
-[Booster.Booster10]: ["4c", "g | vp"]
+  [Booster.Booster1]: ["k,o"],
+  [Booster.Booster2]: ["o,2t"],
+  [Booster.Booster3]: ["q,2c"],
+  [Booster.Booster4]: ["2c", "=> d"],
+  [Booster.Booster5]: ["2pw", "=> 3r"],
+  [Booster.Booster6]: ["o", "m | vp"],
+  [Booster.Booster7]: ["o", "ts | 2vp"],
+  [Booster.Booster8]: ["k", "lab | 3vp"],
+  [Booster.Booster9]: ["4pw", "PA | 4vp"],
+  [Booster.Booster10]: ["4c", "g | vp"]
 };


### PR DESCRIPTION
This manages roundBooster selection during setup and exchange during after the pass move.
Only missing point is to disable roundBoosters during the init phase in Engine:260