### PR TITLE
Income phase

### DIFF
--- a/src/engine.spec.ts
+++ b/src/engine.spec.ts
@@ -535,6 +535,26 @@ describe("Engine", () => {
 
       expect(() => new Engine(moves)).to.not.throw();
     });
+
+    it.only("should allow to decide incomes", () => {
+      const moves = parseMoves(`
+        init 2 randomSeed
+        p1 faction ivits
+        p2 faction nevlas
+        p2 build m 0x-4
+        p2 build m -1x0
+        p1 build PI -2x-4
+        p2 booster booster4
+        p1 booster booster5
+      `);
+
+      const engine = new Engine(moves);
+      expect(() => new Engine([...moves, "p1 income 4pw,t"])).to.not.throw();
+      expect(() => new Engine([...moves, "p1 income t,2pw"])).to.not.throw();
+      expect(() => new Engine([...moves, "p1 income t"])).to.not.throw();
+      expect(() => new Engine([...moves, "p1 income 3pw"])).to.throw();
+    });
+
   });
 
   describe("tech tiles", () => {
@@ -754,25 +774,6 @@ describe("Engine", () => {
 
       expect(() => new Engine(moves)).to.not.throw(AssertionError);
     });
-
-    it("should allow to decide incomes", () => {
-      const moves = parseMoves(`
-      init 2 randomSeed
-      p1 faction ivits
-      p2 faction nevlas
-      p2 build m 0x-4
-      p2 build m -1x0
-      p1 build PI -2x-4
-      p2 booster booster4
-      p1 booster booster5
-      p1 income 4pw. income t
-      `);
-      
-      expect(() => new Engine(moves)).to.not.throw(AssertionError);
-    });
-
-
-
   });
 });
 

--- a/src/engine.spec.ts
+++ b/src/engine.spec.ts
@@ -269,6 +269,7 @@ describe("Engine", () => {
       p1 build PI -1x2.
       p2 leech 1pw
       p1 pass booster3
+      p1 income t
       p2 burn 3. spend 3pw for 1o. pass booster5
       p1 build m -2x3. spend 2pw for 2c.
       p1 build ts -4x2.
@@ -753,6 +754,25 @@ describe("Engine", () => {
 
       expect(() => new Engine(moves)).to.not.throw(AssertionError);
     });
+
+    it("should allow to decide incomes", () => {
+      const moves = parseMoves(`
+      init 2 randomSeed
+      p1 faction ivits
+      p2 faction nevlas
+      p2 build m 0x-4
+      p2 build m -1x0
+      p1 build PI -2x-4
+      p2 booster booster4
+      p1 booster booster5
+      p1 income 4pw. income t
+      `);
+      
+      expect(() => new Engine(moves)).to.not.throw(AssertionError);
+    });
+
+
+
   });
 });
 

--- a/src/engine.spec.ts
+++ b/src/engine.spec.ts
@@ -536,7 +536,7 @@ describe("Engine", () => {
       expect(() => new Engine(moves)).to.not.throw();
     });
 
-    it.only("should allow to decide incomes", () => {
+    it("should allow to decide incomes", () => {
       const moves = parseMoves(`
         init 2 randomSeed
         p1 faction ivits

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -885,13 +885,17 @@ export default class Engine {
     pl.loadEvents(Event.parse(boardActions[action].income));
     this.endTurnPhase(player, Command.Action);
   }
+  
   [Command.ChooseIncome](player: PlayerEnum, income: string) {
     const { incomes } = this.availableCommand(player, Command.ChooseIncome).data;
-    const spec = '+' + income;
+    const incomeRewards = income.split(",") ;
 
-    assert(_.find(incomes, { spec: spec }), `${income} is not in the available income`);
+    for (const incR of incomeRewards) {
+      assert(_.find(incomes, { spec: "+" + incR }), `${incR} is not in the available income`);
+    }
 
-    this.player(player).receiveIncomeEvent(spec);
+
+    this.player(player).receiveIncomeEvent(Reward.parse(income));
 
     this.selectIncomePhase(player);
   }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -891,12 +891,11 @@ export default class Engine {
     const incomeRewards = income.split(",") ;
 
     for (const incR of incomeRewards) {
-      assert(_.find(incomes, { spec: "+" + incR }), `${incR} is not in the available income`);
+      const eventIdx = incomes.findIndex(ev => Reward.match(Reward.parse(incR), ev.rewards));
+      assert(eventIdx > -1, `${incR} is not in the available income`);
+      incomes.splice(eventIdx, 1);
     }
-
-
     this.player(player).receiveIncomeEvent(Reward.parse(income));
-
     this.selectIncomePhase(player);
   }
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -885,7 +885,6 @@ export default class Engine {
     pl.loadEvents(Event.parse(boardActions[action].income));
     this.endTurnPhase(player, Command.Action);
   }
-  
   [Command.ChooseIncome](player: PlayerEnum, income: string) {
     const { incomes } = this.availableCommand(player, Command.ChooseIncome).data;
     const spec = '+' + income;

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -134,6 +134,7 @@ export enum Command {
   ChooseTechTile = "tech",
   ChooseCoverTechTile = "cover",
   ChooseFederationTile = "fedtile",
+  ChooseIncome = "income",
   Build = "build",
   Pass = "pass",
   UpgradeResearch = "up",

--- a/src/faction-boards/ambas.ts
+++ b/src/faction-boards/ambas.ts
@@ -3,7 +3,7 @@ import { FactionBoardRaw } from ".";
 
 const ambas: FactionBoardRaw = {
   [Building.PlanetaryInstitute]: {
-    income: ["+4pw","+2t"]
+    income: ["+4pw", "+2t"]
   },
   income: ["3k,4o,15c,q,up-nav", "+2o,k"]
 };

--- a/src/faction-boards/ambas.ts
+++ b/src/faction-boards/ambas.ts
@@ -3,7 +3,7 @@ import { FactionBoardRaw } from ".";
 
 const ambas: FactionBoardRaw = {
   [Building.PlanetaryInstitute]: {
-    income: ["+4pw,2t"]
+    income: ["+4pw","+2t"]
   },
   income: ["3k,4o,15c,q,up-nav", "+2o,k"]
 };

--- a/src/faction-boards/bescods.ts
+++ b/src/faction-boards/bescods.ts
@@ -9,7 +9,7 @@ const bescods: FactionBoardRaw = {
     income: ["+3c", "+4c", "+5c"]
   },
   [Building.PlanetaryInstitute]: {
-    income: ["+4pw","+2t"]
+    income: ["+4pw", "+2t"]
   },
   income: ["k,4o,15c,q", "+o"]
 };

--- a/src/faction-boards/bescods.ts
+++ b/src/faction-boards/bescods.ts
@@ -9,7 +9,7 @@ const bescods: FactionBoardRaw = {
     income: ["+3c", "+4c", "+5c"]
   },
   [Building.PlanetaryInstitute]: {
-    income: ["+4pw,2t"]
+    income: ["+4pw","+2t"]
   },
   income: ["k,4o,15c,q", "+o"]
 };

--- a/src/faction-boards/gleens.ts
+++ b/src/faction-boards/gleens.ts
@@ -3,7 +3,7 @@ import { Building } from "../enums";
 
 const gleens: FactionBoardRaw = {
   [Building.PlanetaryInstitute]: {
-    income: ["+4pw","+o"]
+    income: ["+4pw", "+o"]
   },
   income: ["3k,4o,15c", "+o,k"]
 };

--- a/src/faction-boards/gleens.ts
+++ b/src/faction-boards/gleens.ts
@@ -3,7 +3,7 @@ import { Building } from "../enums";
 
 const gleens: FactionBoardRaw = {
   [Building.PlanetaryInstitute]: {
-    income: ["+4pw,o"]
+    income: ["+4pw","+o"]
   },
   income: ["3k,4o,15c", "+o,k"]
 };

--- a/src/faction-boards/types.ts
+++ b/src/faction-boards/types.ts
@@ -65,7 +65,7 @@ const defaultBoard: FactionBoardRaw = {
   },
   [Building.PlanetaryInstitute]: {
     cost: "6c,4o",
-    income: ["+4pw","+t"]
+    income: ["+4pw", "+t"]
   },
   [Building.GaiaFormer]: {
     cost: "6tg",
@@ -76,7 +76,7 @@ const defaultBoard: FactionBoardRaw = {
     area1: 2,
     area2: 4
   },
-  brainstone : BrainstoneArea.Out
+  brainstone: BrainstoneArea.Out
 };
 
 export class FactionBoard {
@@ -135,7 +135,7 @@ export class FactionBoard {
     return this[building].income.length;
   }
 
-  cost( targetPlanet: Planet, building: Building, isolated = true): Reward[] {
+  cost(targetPlanet: Planet, building: Building, isolated = true): Reward[] {
 
     if (building === Building.TradingStation && isolated) {
       return this[building].isolatedCost;

--- a/src/faction-boards/types.ts
+++ b/src/faction-boards/types.ts
@@ -65,7 +65,7 @@ const defaultBoard: FactionBoardRaw = {
   },
   [Building.PlanetaryInstitute]: {
     cost: "6c,4o",
-    income: ["+4pw,t"]
+    income: ["+4pw","+t"]
   },
   [Building.GaiaFormer]: {
     cost: "6tg",

--- a/src/faction-boards/xenos.ts
+++ b/src/faction-boards/xenos.ts
@@ -3,7 +3,7 @@ import { Building } from "../enums";
 
 const xenos: FactionBoardRaw = {
   [Building.PlanetaryInstitute]: {
-    income: ["+4pw,q"]
+    income: ["+4pw","+q"]
   },
   income: ["3k,4o,15c,q,up-int", "+o,k"]
 };

--- a/src/faction-boards/xenos.ts
+++ b/src/faction-boards/xenos.ts
@@ -3,7 +3,7 @@ import { Building } from "../enums";
 
 const xenos: FactionBoardRaw = {
   [Building.PlanetaryInstitute]: {
-    income: ["+4pw","+q"]
+    income: ["+4pw", "+q"]
   },
   income: ["3k,4o,15c,q,up-int", "+o,k"]
 };

--- a/src/player.ts
+++ b/src/player.ts
@@ -194,10 +194,10 @@ export default class Player extends EventEmitter {
     //it's assuming that each reward belongs to a different event, which has only that reward  
     //in case of multiple matchings pick the first
     for ( const rew of rewards) {
-      const event =  this.events[Operator.Income].filter( ev => !ev.activated && ev.rewards.length === 1 && ev.rewards[0].type === rew.type && ev.rewards[0].count === rew.count);
+      const event =  this.events[Operator.Income].find( ev => !ev.activated && Reward.match( [rew], ev.rewards));
       if (event) {
-        this.gainRewards(event[0].rewards);
-        event[0].activated = true;
+        this.gainRewards(event.rewards);
+        event.activated = true;
       }
     }
   }
@@ -215,7 +215,7 @@ export default class Player extends EventEmitter {
   build(building: Building, hex: GaiaHex, cost: Reward[], map: SpaceMap, stepsReq: number) {
     this.payCosts(cost);
     // excluding Gaiaformers as occupied
-    if ( building !== Building.GaiaFormer ) {
+    if (building !== Building.GaiaFormer) {
       this.data.occupied = _.uniqWith([].concat(this.data.occupied, hex), _.isEqual);
     }
 
@@ -223,11 +223,11 @@ export default class Player extends EventEmitter {
     if (hex.data.planet !== Planet.Lost) {
       if (building === Building.PlanetaryInstitute) {
         // PI has different events
-        this.loadEvents( this.board[Building.PlanetaryInstitute].income );
+        this.loadEvents(this.board[Building.PlanetaryInstitute].income);
       } else {
         // Add income of the building to the list of events
         this.loadEvent(this.board[building].income[this.data[building]]);
-        }
+      }
       this.data[building] += 1;
     }
 
@@ -307,6 +307,7 @@ export default class Player extends EventEmitter {
     for (const event of this.events[Operator.Income]) {
       if ( !event.activated ) {
         this.gainRewards(event.rewards);
+        event.activated = true;
       }
     }
   }

--- a/src/player.ts
+++ b/src/player.ts
@@ -189,6 +189,17 @@ export default class Player extends EventEmitter {
     }
   }
 
+  receiveIncomeEvent(spec: string) {
+    for (const event of this.events[Operator.Income]) {
+      if (event.spec === spec && !event.activated) {
+        this.gainRewards(event.rewards);
+        event.activated = true;
+        return;
+      }
+    }
+  }
+  
+  
   onResearchAdvanced(field: ResearchField) {
     const events = Event.parse(researchTracks[field][this.data.research[field]]);
     this.loadEvents(events);
@@ -207,8 +218,13 @@ export default class Player extends EventEmitter {
 
     // The mine of the lost planet doesn't grant any extra income
     if (hex.data.planet !== Planet.Lost) {
-      // Add income of the building to the list of events
-      this.loadEvent(this.board[building].income[this.data[building]]);
+      if (building === Building.PlanetaryInstitute) {
+        // PI has different events
+        this.loadEvents( this.board[Building.PlanetaryInstitute].income );
+      } else {
+        // Add income of the building to the list of events
+        this.loadEvent(this.board[building].income[this.data[building]]);
+        }
       this.data[building] += 1;
     }
 
@@ -286,7 +302,9 @@ export default class Player extends EventEmitter {
 
   receiveIncome() {
     for (const event of this.events[Operator.Income]) {
-      this.gainRewards(event.rewards);
+      if ( !event.activated ) {
+        this.gainRewards(event.rewards);
+      }
     }
   }
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -189,12 +189,15 @@ export default class Player extends EventEmitter {
     }
   }
 
-  receiveIncomeEvent(spec: string) {
-    for (const event of this.events[Operator.Income]) {
-      if (event.spec === spec && !event.activated) {
-        this.gainRewards(event.rewards);
-        event.activated = true;
-        return;
+  receiveIncomeEvent(rewards: Reward[]) {
+    //this is managing Income phase to solve +t and +pw ordering
+    //it's assuming that each reward belongs to a different event, which has only that reward  
+    //in case of multiple matchings pick the first
+    for ( const rew of rewards) {
+      const event =  this.events[Operator.Income].filter( ev => !ev.activated && ev.rewards.length === 1 && ev.rewards[0].type === rew.type && ev.rewards[0].count === rew.count);
+      if (event) {
+        this.gainRewards(event[0].rewards);
+        event[0].activated = true;
       }
     }
   }

--- a/src/tiles/boosters.ts
+++ b/src/tiles/boosters.ts
@@ -1,14 +1,14 @@
 import { Booster } from "../enums";
 
 export default  {
-  [Booster.Booster1]: ["k,o"],
-  [Booster.Booster2]: ["o,2t"],
-  [Booster.Booster3]: ["q,2c"],
-  [Booster.Booster4]: ["2c", "=> tempstep"],
-  [Booster.Booster5]: ["2pw", "=> 3temprange"],
-  [Booster.Booster6]: ["o", "m | vp"],
-  [Booster.Booster7]: ["o", "ts | 2vp"],
-  [Booster.Booster8]: ["k", "lab | 3vp"],
-  [Booster.Booster9]: ["4pw", "PA | 4vp"],
-  [Booster.Booster10]: ["4c", "g | vp"]
+  [Booster.Booster1]: ["+k,o"],
+  [Booster.Booster2]: ["+o", "+2t"],
+  [Booster.Booster3]: ["+q,2c"],
+  [Booster.Booster4]: ["+2c", "=> tempstep"],
+  [Booster.Booster5]: ["+2pw", "=> 3temprange"],
+  [Booster.Booster6]: ["+o", "m | vp"],
+  [Booster.Booster7]: ["+o", "ts | 2vp"],
+  [Booster.Booster8]: ["+k", "lab | 3vp"],
+  [Booster.Booster9]: ["+4pw", "PA | 4vp"],
+  [Booster.Booster10]: ["+4c", "g | vp"]
 };


### PR DESCRIPTION
Requests for income order if there are +t and +pw in the same time. Iterates until the condition is not met and calculate gets remaining incomes.
It's assuming that each income is a separate action, which is accordingly to the boardgame. Therefore PI have two different incomes that we load we PI has been build.
