### PR TITLE
Build a mine as additional action fix. Close #67

### DIFF
--- a/src/available-command.ts
+++ b/src/available-command.ts
@@ -114,6 +114,7 @@ export function generate(engine: Engine): AvailableCommand[] {
             break;
           }
 
+          case Command.Build:
           case Command.EndTurn: {
             commands.push(subCommand);
 
@@ -124,8 +125,8 @@ export function generate(engine: Engine): AvailableCommand[] {
 
           default: commands.push(subCommand);
         }
-        // remove playerPassiveCommands but not endTurn
-        if ( engine.roundSubCommands[0].name !== Command.EndTurn ) {
+        // remove playerPassiveCommands but not endTurn or BuildsubPhase
+        if (engine.roundSubCommands[0].name !== Command.EndTurn && engine.roundSubCommands[0].name !== Command.Build) {
           engine.roundSubCommands.splice(0, 1);
         }
 

--- a/src/engine.spec.ts
+++ b/src/engine.spec.ts
@@ -443,7 +443,7 @@ describe("Engine", () => {
       expect(data.federations.includes(Federation.FederationGleens)).to.be.true;
     });
 
-    it ("should grant gleens two victory points when building a mine on a gaia planet", () => {
+    it('should grant gleens two victory points when building a mine on a gaia planet', () => {
       const engine = new Engine(parseMoves(`
         init 2 randomSeed
         p1 faction gleens
@@ -462,7 +462,7 @@ describe("Engine", () => {
       `));
 
       const vp = engine.player(Player.Player1).data.victoryPoints;
-      engine.move("p1 build m -2x3");
+      engine.move('p1 build m -2x3');
       expect(engine.player(Player.Player1).data.victoryPoints).to.equal(vp + 2);
     });
   });
@@ -796,7 +796,7 @@ describe("Engine", () => {
       `);
 
       const engine = new Engine(moves);
-      const vp = engine.player(Player.Player1).data.victoryPoints;
+      const vp = engine.player(Player.Player2).data.victoryPoints;
 
       engine.move("p2 pass booster3");
 

--- a/src/engine.spec.ts
+++ b/src/engine.spec.ts
@@ -814,12 +814,18 @@ describe("Engine", () => {
         p1 build m -1x2
         p2 booster booster5
         p1 booster booster4
-        p1 special tempstep
       `);
       const engine = new Engine(moves);
 
       // tslint:disable-next-line no-unused-expression
-      expect(engine.player(Player.Player1).events[Operator.Activate][0].activated).to.be.true;
+      expect(() => new Engine([...moves, "p1 special tempstep"])).to.not.throw();
+      expect(new Engine([...moves, "p1 special tempstep"]).player(Player.Player1).events[Operator.Activate][0].activated).to.be.true;
+
+      // test free action before and after, and to build something different then a mine
+      expect(() => new Engine([...moves, "p1 special tempstep. spend 1o for 1c. build m -1x-1. spend 1o for 1c."])).to.not.throw();
+      expect(() => new Engine([...moves, "p1 special tempstep. spend 1o for 1c. build ts -4x2"])).to.throw();
+      expect(() => new Engine([...moves, "p1 special tempstep. build m -1x-1. spend 1o for 1c."])).to.not.throw();
+     
     });
 
     it("should allow to use a range special action from a booster", () => {
@@ -833,9 +839,9 @@ describe("Engine", () => {
         p1 build m -3x4
         p2 booster booster5
         p1 booster booster4
-        p1 special tempstep. build m -1x-1.
+        p1 special tempstep. spend 1o for 1c. build m -1x-1.
         p2 leech 1pw
-        p2 special 3temprange. build m 3x-3.
+        p2 special 3temprange. spend 1o for 1c. build m 3x-3.
       `);
 
       expect(() => new Engine(moves)).to.not.throw(AssertionError);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -671,6 +671,11 @@ export default class Engine {
           elem.steps
         );
 
+        //remove subCommand build if present
+        if (this.roundSubCommands[0] && this.roundSubCommands[0].name === Command.Build) {
+          this.roundSubCommands.splice(0, 1);
+        }
+
         this.leechingPhase(player, hex);
 
         if ( pl.faction === Faction.Gleens && building === Building.PlanetaryInstitute) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -289,7 +289,7 @@ export default class Engine {
   incomePhase() {
     for (const player of this.playersInOrder()) {
       this.selectIncomePhase(player.player);
-      player.loadEvents( Event.parse(roundScorings[this.roundScoringTiles[this.round]]));
+      player.loadEvents(this.currentRoundScoringEvents);
     }
 
   };


### PR DESCRIPTION
This allow action before and after, and only build a mine or gaia former during the new action
Fix also the wrong round booster assignment