### PR TITLE
Terrans

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -18,6 +18,13 @@ export const freeActionsHadschHallas = [
   { cost: "4c", income: "1k" }
 ];
 
+export const freeActionsTerrans = [
+  { cost: "4tg", income: "1q" },
+  { cost: "3tg", income: "1o" },
+  { cost: "4tg", income: "1k" },
+  { cost: "1tg", income: "1c" }
+];
+
 export const boardActions =  {
   [BoardAction.Power1]: { cost: "7pw", income: ["3k"] },
   [BoardAction.Power2]: { cost: "5pw", income: ["2step"] },

--- a/src/available-command.ts
+++ b/src/available-command.ts
@@ -5,7 +5,7 @@ import factions from './factions';
 import * as assert from "assert";
 import { upgradedBuildings } from './buildings';
 import Reward from './reward';
-import { boardActions, freeActions, freeActionsHadschHallas } from './actions';
+import { boardActions, freeActions, freeActionsHadschHallas, freeActionsTerrans } from './actions';
 import * as researchTracks from './research-tracks';
 import { terraformingStepsRequired } from './planets';
 
@@ -101,6 +101,11 @@ export function generate(engine: Engine): AvailableCommand[] {
                 tilePos: Object.values(TechTilePos).find(pos => engine.techTiles[pos].tile === tech.tile)
               }))}
             });
+            break;
+          }
+
+          case Command.Spend: {
+            commands.push(...possibleFreeActions(engine, subCommand.player, subCommand.data));
             break;
           }
 
@@ -329,7 +334,7 @@ export function possibleBoardActions(engine: Engine, player: Player) {
 
 }
 
-export function possibleFreeActions(engine: Engine, player: Player) {
+export function possibleFreeActions(engine: Engine, player: Player, gaiaPhase?: boolean) {
   // free action - spend
   const pl = engine.player(player);
   const acts = [];
@@ -338,6 +343,11 @@ export function possibleFreeActions(engine: Engine, player: Player) {
   let pool = freeActions;
   if (pl.faction === Faction.HadschHallas && pl.data.hasPlanetaryInstitute()) {
     pool = [].concat(pool, freeActionsHadschHallas);
+  }
+
+  //freeActions for Terrans during gaiaPhase
+  if ( gaiaPhase && engine.player(player).faction === Faction.Terrans) {
+    pool = freeActionsTerrans;
   }
 
   for (const freeAction of pool) {

--- a/src/engine.spec.ts
+++ b/src/engine.spec.ts
@@ -244,7 +244,7 @@ describe("Engine", () => {
     expect(() => engine.move("p1 up gaia.")).to.throw();
   });
 
-  it("should allow to form a federation and gain rewards", () => {
+  it("should allow to form a federation and gain rewards. Gaia phase to test income for terrans", () => {
     const moves = parseMoves(`
       init 2 randomSeed
       p1 faction terrans
@@ -269,7 +269,7 @@ describe("Engine", () => {
       p1 build PI -1x2.
       p2 leech 1pw
       p1 pass booster3
-      p1 income t
+      p1 income t. spend 4tg for 1k. spend 2tg for 2c
       p2 burn 3. spend 3pw for 1o. pass booster5
       p1 build m -2x3. spend 2pw for 2c.
       p1 build ts -4x2.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -333,7 +333,7 @@ export default class Engine {
     if (pl.data.gaiaPowerTokens() > 0 && pl.faction === Faction.Terrans && pl.data.hasPlanetaryInstitute()) {
       this.roundSubCommands.push({
         name: Command.Spend,
-        player: player,
+        player,
         data: { gaiaPhase: true }
       });
 
@@ -883,7 +883,7 @@ export default class Engine {
     pl.payCosts(cost);
     pl.gainRewards(income);
 
-    // check if it's a gaia phase 
+    // check if it's a gaia phase
     if (cost[0].type === Resource.GainTokenGaiaArea) {
 
       if (pl.data.brainstone === BrainstoneArea.Transit) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -885,13 +885,7 @@ export default class Engine {
 
     // check if it's a gaia phase
     if (cost[0].type === Resource.GainTokenGaiaArea) {
-
-      if (pl.data.brainstone === BrainstoneArea.Transit) {
-        pl.data.brainstone = BrainstoneArea.Area2;
-        pl.data.power.area2 += cost[0].count - 1;
-      } else {
-        pl.data.power.area2 += cost[0].count;
-      }
+      pl.data.power.area2 += cost[0].count;
       this.selectGaiaPhase(player);
     }
   }

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -83,7 +83,8 @@ export enum Condition {
   // trigger only
   MineOnGaia = "g",
   AdvanceResearch = "a",
-  TerraformStep = "step"
+  TerraformStep = "step",
+  GaiaFormer = "gf"
 }
 
 export namespace Condition {
@@ -285,5 +286,6 @@ export enum BrainstoneArea {
   Area1 = "area1",
   Area2 = "area2",
   Area3 = "area3",
-  Gaia = "gaia"
+  Gaia = "gaia",
+  Transit = "transit"
 }

--- a/src/faction-boards/types.ts
+++ b/src/faction-boards/types.ts
@@ -68,7 +68,7 @@ const defaultBoard: FactionBoardRaw = {
     income: ["+4pw", "+t"]
   },
   [Building.GaiaFormer]: {
-    cost: "6tg",
+    cost: "6t",
     income: ["~", "~", "~"]
   },
   income: ["3k,4o,15c,q", "+o,k"],

--- a/src/player-data.spec.ts
+++ b/src/player-data.spec.ts
@@ -10,17 +10,34 @@ describe("PlayerData", () => {
     expect(data.toJSON()).to.be.an.instanceof(Object);
   });
 
-  describe("movePowerToGaia", () => {
+  describe("discardPower", () => {
     it ("should remove power tokens from power areas", () => {
       const data = new PlayerData();
       data.power.area1 = 4;
       data.power.area2 = 4;
 
-      data.discardPower(6, Resource.GainTokenGaiaArea);
+      data.discardPower(6);
 
       expect(data.power.area1).to.equal(0);
       expect(data.power.area2).to.equal(2);
-      expect(data.power.gaia).to.equal(6);
+      expect(data.power.gaia).to.equal(0);
+      expect(data.brainstone).to.equal(BrainstoneArea.Out)
+    });
+  });
+
+  describe("discardPower with brainstone in play", () => {
+    it ("should remove power tokens from power areas and brainstone in transit", () => {
+      const data = new PlayerData();
+      data.power.area1 = 4;
+      data.power.area2 = 1;
+      data.brainstone = BrainstoneArea.Area2;
+
+      data.discardPower(6);
+
+      expect(data.power.area1).to.equal(0);
+      expect(data.power.area2).to.equal(0);
+      expect(data.power.gaia).to.equal(0);
+      expect(data.brainstone).to.equal(BrainstoneArea.Transit)
     });
   });
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -121,8 +121,7 @@ export default class Player extends EventEmitter {
 
     // gaiaforming discount
     if (building === Building.GaiaFormer) {
-      const gaiaformingDiscount =  this.data.gaiaformers > 1  ? this.data.gaiaformers : 0;
-      addedCost.push(new Reward(-gaiaformingDiscount, Resource.GainTokenGaiaArea));
+      addedCost.push(new Reward(-this.data.gaiaFormingDiscount(), Resource.GainToken));
     } else if (building === Building.Mine) {
       // habitability costs
       if (targetPlanet === Planet.Gaia) {
@@ -229,7 +228,7 @@ export default class Player extends EventEmitter {
     if (building !== Building.GaiaFormer) {
       this.data.occupied = _.uniqWith([].concat(this.data.occupied, hex), _.isEqual);
     }
-
+    
     // The mine of the lost planet doesn't grant any extra income
     if (hex.data.planet !== Planet.Lost) {
       if (building === Building.PlanetaryInstitute) {
@@ -292,6 +291,11 @@ export default class Player extends EventEmitter {
     // reset temporary benefits
     this.data.temporaryRange = 0;
     this.data.temporaryStep = 0;
+
+    // removes brainstone if still in transit after turn End
+    if ( this.data.brainstone === BrainstoneArea.Transit) {
+      this.data.brainstone = BrainstoneArea.Out
+    }
   }
 
   pass() {
@@ -383,6 +387,9 @@ export default class Player extends EventEmitter {
     // Terrans move directly to power area 2
     if (this.faction === Faction.Terrans) {
       this.data.power.area2 += this.data.power.gaia;
+      if (this.data.brainstone === BrainstoneArea.Gaia ) {
+        this.data.brainstone = BrainstoneArea.Area2;
+      }
     } else {
       this.data.power.area1 += this.data.power.gaia;
       if (this.data.brainstone === BrainstoneArea.Gaia ) {

--- a/src/research-tracks.ts
+++ b/src/research-tracks.ts
@@ -12,7 +12,7 @@ export default {
     [], ["q"], ["q"], ["2q,3pw"], ["2q"], ["4q"]
   ],
   [ResearchField.GaiaProject]: [
-    [], ["gf"], ["3t"], ["3pw", "gf"], ["gf"], ["4vp", "g > vp"]
+    [], [">gf", "gf >> 6tg"], ["3t", "gf >> 6tg"], ["3pw", ">gf", "gf >> 4tg"], [">gf", "gf >> 3tg"], ["4vp", "gf >> 3tg", "g > vp"]
   ],
   [ResearchField.Economy]: [
     [], ["+2c,pw"], ["+2c,1o,2pw"], ["+3c,1o,3pw", "3pw"], ["+2o,4c,4pw"], ["3o,6c,6pw"]


### PR DESCRIPTION
Gaiaforming now costs t and gives tg. Resource.GainGaiaToke (tg) has is proper discard and load functions.
This helps to use the existing `spend` command `spend 4tg for 1o`. 
Brainstone has and intermediate state `Transit`, which helps to move brain stones between areas.
Gaia phase works the same way the income phase works. To manage order between income and gaia, gaia subcommands are pushed, while income are unshift.

Closes #21 