### PR TITLE
Rework the flow.

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -17,7 +17,10 @@ app.post("/", (req, res) => {
   try {
     const moves = req.body.moves;
     const engine = new Engine(moves);
-    engine.generateAvailableCommands();
+
+    if (!engine.availableCommands) {
+      engine.generateAvailableCommands();
+    }
 
     res.json(engine);
   } catch (err) {

--- a/src/buildings.ts
+++ b/src/buildings.ts
@@ -24,15 +24,3 @@ export function stdBuildingValue(building: Building): number {
   return 0;
 }
 
-export function maxBuildings(building: Building): number {
-  switch (building) {
-    case Building.Mine: return 8;
-    case Building.TradingStation: return 4;
-    case Building.ResearchLab: return 3;
-    case Building.PlanetaryInstitute: return 1;
-    case Building.Academy1:
-    case Building.Academy2: return 1;
-  }
-
-  return 0;
-}

--- a/src/engine.spec.ts
+++ b/src/engine.spec.ts
@@ -251,7 +251,9 @@ describe("Engine", () => {
       p1 build ac1 -3x4. tech free2. up gaia.
       p2 leech 3pw
       p2 pass booster8
-      p1 build gf -2x3.. special 4pw. spend 4pw for 1k.. pass booster7
+      p1 build gf -2x3.
+      p1 special 4pw. spend 4pw for 1k.
+      p1 pass booster7
       p2 action power5.
       p1 build m -2x3.
       p2 leech 3pw
@@ -442,7 +444,6 @@ describe("Engine", () => {
     expect(() => new Engine([...moves, "p2 special piswap. piswap 5x-3."])).to.not.throw();
     expect(() => new Engine([...moves, "p2 special piswap. piswap 3x-3."])).to.throw();
   });
-
 
   describe("gleens", () => {
     it ("should grant gleens an ore instead of qic when upgrading navigation without an academy", () => {
@@ -790,7 +791,9 @@ describe("Engine", () => {
         p1 build ac1 -3x4. tech free2. up gaia.
         p2 leech 3pw
         p2 pass booster8
-        p1 build gf -2x3.. special 4pw. spend 4pw for 1k.. pass booster7
+        p1 build gf -2x3.
+        p1 special 4pw. spend 4pw for 1k.
+        p1 pass booster7
         p2 action power5.
         p1 build m -2x3.
         p2 leech 3pw
@@ -908,13 +911,12 @@ describe("Engine", () => {
       // tslint:disable-next-line no-unused-expression
       expect(() => new Engine([...moves, "p1 special step"])).to.not.throw();
       // tslint:disable-next-line no-unused-expression
-      expect(new Engine([...moves, "p1 special step"]).player(Player.Player1).events[Operator.Activate][0].activated).to.be.true;
+      expect(new Engine([...moves, "p1 special step. build m -2x2."]).player(Player.Player1).events[Operator.Activate][0].activated).to.be.true;
 
       // test free action before and after, and to build something different then a mine
-      expect(() => new Engine([...moves, "p1 special step. spend 1o for 1c. build m -1x-1. spend 1o for 1c."])).to.not.throw();
-      expect(() => new Engine([...moves, "p1 special step. spend 1o for 1c. build ts -4x2"])).to.throw();
+      expect(() => new Engine([...moves, "p1 spend 2o for 2c. special step. build m -1x-1"])).to.not.throw();
+      expect(() => new Engine([...moves, "p1 spend 1o for 1c. special step. build ts -4x2"])).to.throw();
       expect(() => new Engine([...moves, "p1 special step. build m -1x-1. spend 1o for 1c."])).to.not.throw();
-
     });
 
     it("should allow to use a range special action from a booster", () => {
@@ -928,9 +930,9 @@ describe("Engine", () => {
         p1 build m -3x4
         p2 booster booster5
         p1 booster booster4
-        p1 special step. spend 1o for 1c. build m -1x-1.
+        p1 spend 1o for 1c. special step. build m -1x-1.
         p2 leech 1pw
-        p2 special range+3. spend 1o for 1c. build m 3x-3.
+        p2 spend 1o for 1c. special range+3. build m 3x-3.
       `);
 
       expect(() => new Engine(moves)).to.not.throw(AssertionError);

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -168,7 +168,8 @@ export enum Round {
   Round3= 3,
   Round4= 4,
   Round5= 5,
-  Round6= 6
+  Round6= 6,
+  LastRound = 6
 }
 
 export enum Booster {
@@ -308,7 +309,6 @@ export enum Phase {
 export enum SubPhase {
   BeforeMove = "beforeMove",
   AfterMove = "afterMove",
-  EndMove = "endMove",
   UpgradeResearch = "upgradeResearch",
   PlaceLostPlanet = "placeLostPlanet",
   ChooseTechTile = "chooseTechTile",

--- a/src/faction-boards/ambas.ts
+++ b/src/faction-boards/ambas.ts
@@ -3,7 +3,7 @@ import { FactionBoardRaw } from ".";
 
 const ambas: FactionBoardRaw = {
   [Building.PlanetaryInstitute]: {
-    income: ["+4pw", "+2t", "=> piswap"]
+    income: [["+4pw", "+2t", "=> piswap"]]
   },
   income: ["3k,4o,15c,q,up-nav", "+2o,k"]
 };

--- a/src/faction-boards/baltaks.ts
+++ b/src/faction-boards/baltaks.ts
@@ -2,13 +2,9 @@ import { FactionBoardRaw } from ".";
 import { Building } from "../enums";
 
 const baltaks: FactionBoardRaw = {
-  [Building.Academy1]: {
-    cost: "6c,6o",
-    income: ["+2k"]
-  },
   [Building.Academy2]: {
     cost: "6c,6o",
-    income: ["=>4c"]
+    income: [["=>4c", "tech"]]
   },
   income: ["3k,4o,15c,up-gaia", "+o,k"],
   power: {

--- a/src/faction-boards/bescods.ts
+++ b/src/faction-boards/bescods.ts
@@ -3,13 +3,13 @@ import { Building } from "../enums";
 
 const bescods: FactionBoardRaw = {
   [Building.TradingStation]: {
-    income: ["+k", "+k", "+k", "+k"],
+    income: [["+k"], ["+k"], ["+k"], ["+k"]],
   },
   [Building.ResearchLab]: {
-    income: ["+3c", "+4c", "+5c"]
+    income: [["+3c", "tech"], ["+4c", "tech"], ["+5c", "tech"]]
   },
   [Building.PlanetaryInstitute]: {
-    income: ["+4pw", "+2t"]
+    income: [["+4pw", "+2t"]]
   },
   income: ["k,4o,15c,q", "+o"]
 };

--- a/src/faction-boards/gleens.ts
+++ b/src/faction-boards/gleens.ts
@@ -1,11 +1,15 @@
 import { FactionBoardRaw } from ".";
-import { Building } from "../enums";
+import { Building, Federation } from "../enums";
+import Player from "../player";
 
 const gleens: FactionBoardRaw = {
   [Building.PlanetaryInstitute]: {
-    income: ["+4pw", "+o"]
+    income: [["+4pw", "+o"]]
   },
-  income: ["3k,4o,15c", "+o,k", "g >> 2vp"]
+  income: ["3k,4o,15c", "+o,k", "g >> 2vp"],
+  handlers: {
+    'planetary-institute': (player: Player) => player.gainFederationToken(Federation.FederationGleens)
+  }
 };
 
 export default gleens;

--- a/src/faction-boards/itars.ts
+++ b/src/faction-boards/itars.ts
@@ -3,10 +3,7 @@ import { Building } from "../enums";
 
 const itars: FactionBoardRaw = {
   [Building.Academy1]: {
-    income: ["+3k"]
-  },
-  [Building.Academy2]: {
-    income: ["=>q"]
+    income: [["+3k", "tech"]]
   },
   income: ["3k,5o,15c,q", "+o,k,t"],
   power: {

--- a/src/faction-boards/lantids.ts
+++ b/src/faction-boards/lantids.ts
@@ -3,7 +3,7 @@ import { FactionBoardRaw } from ".";
 
 const lantids: FactionBoardRaw = {
   [Building.PlanetaryInstitute]: {
-    income: ["+4pw"]
+    income: [["+4pw"]]
   },
   income: ["3k,4o,13c,q", "+o,k"],
   power: {

--- a/src/faction-boards/nevlas.ts
+++ b/src/faction-boards/nevlas.ts
@@ -1,14 +1,18 @@
 import { FactionBoardRaw } from ".";
 import { Building } from "../enums";
+import Player from "../player";
 
 const nevlas: FactionBoardRaw = {
   [Building.TradingStation]: {
-    income: ["+3c", "+4c", "+4c", "+5c"],
+    income: [["+3c"], ["+4c"], ["+4c"], ["+5c"]],
   },
   [Building.ResearchLab]: {
-    income: ["+2pw", "+2pw", "+2pw"]
+    income: [["+2pw", "tech"], ["+2pw", "tech"], ["+2pw", "tech"]]
   },
-  income: ["2k,4o,15c,q,up-sci", "+o,k"]
+  income: ["2k,4o,15c,q,up-sci", "+o,k"],
+  handlers: {
+    'planetary-institute': (player: Player) => player.data.tokenModifier = 2
+  }
 };
 
 export default nevlas;

--- a/src/faction-boards/types.ts
+++ b/src/faction-boards/types.ts
@@ -2,36 +2,37 @@ import Reward from "../reward";
 import * as _ from "lodash";
 import Event from "../events";
 import { Building, Planet, BrainstoneArea } from "../enums";
+import Player from "../player";
 
 export interface FactionBoardRaw {
   [Building.Mine]?: {
     cost?: string,
-    income?: string[]
+    income?: string[][]
   };
   [Building.TradingStation]?: {
     cost?: string,
     isolatedCost?: string,
-    income?: string[]
+    income?: string[][]
   };
   [Building.ResearchLab]?: {
     cost?: string,
-    income?: string[]
+    income?: string[][]
   };
   [Building.Academy1]?: {
     cost?: string,
-    income?: string[]
+    income?: string[][]
   };
   [Building.Academy2]?: {
     cost?: string,
-    income?: string[]
+    income?: string[][]
   };
   [Building.PlanetaryInstitute]?: {
     cost?: string,
-    income?: string[]
+    income?: string[][]
   };
   [Building.GaiaFormer]?: {
     cost?: string,
-    income?: string[]
+    income?: string[][]
   };
   income?: string[];
   power?: {
@@ -39,75 +40,77 @@ export interface FactionBoardRaw {
     area2?: number
   };
   brainstone?: BrainstoneArea;
+  handlers?: {[event: string]: (player: Player, ...args: any[]) => any};
 }
 
 const defaultBoard: FactionBoardRaw = {
   [Building.Mine]: {
     cost: "2c,o",
-    income: ["+o", "+o", "~", "+o", "+o", "+o", "+o", "+o"]
+    income: [["+o"], ["+o"], [], ["+o"], ["+o"], ["+o"], ["+o"], ["+o"]]
   },
   [Building.TradingStation]: {
     cost: "3c,2o",
     isolatedCost: "6c,2o",
-    income: ["+3c", "+4c", "+4c", "+5c"]
+    income: [["+3c"], ["+4c"], ["+4c"], ["+5c"]]
   },
   [Building.ResearchLab]: {
     cost: "5c,3o",
-    income: ["+k", "+k", "+k"]
+    income: [["+k", "tech"], ["+k", "tech"], ["+k", "tech"]]
   },
   [Building.Academy1]: {
     cost: "6c,6o",
-    income: ["+2k"]
+    income: [["+2k", "tech"]]
   },
   [Building.Academy2]: {
     cost: "6c,6o",
-    income: ["=>q"]
+    income: [["=>q", "tech"]]
   },
   [Building.PlanetaryInstitute]: {
     cost: "6c,4o",
-    income: ["+4pw", "+t"]
+    income: [["+4pw", "+t"]]
   },
   [Building.GaiaFormer]: {
     cost: "6t",
-    income: ["~", "~", "~"]
+    income: [[], [], []]
   },
   income: ["3k,4o,15c,q", "+o,k"],
   power: {
     area1: 2,
     area2: 4
   },
-  brainstone: BrainstoneArea.Out
+  brainstone: BrainstoneArea.Out,
+  handlers: {}
 };
 
 export class FactionBoard {
   [Building.Mine]: {
     cost: Reward[],
-    income: Event[]
+    income: Event[][]
   };
   [Building.TradingStation]: {
     cost: Reward[],
     isolatedCost: Reward[],
-    income: Event[]
+    income: Event[][]
   };
   [Building.ResearchLab]: {
     cost: Reward[],
-    income: Event[]
+    income: Event[][]
   };
   [Building.Academy1]: {
     cost: Reward[],
-    income: Event[]
+    income: Event[][]
   };
   [Building.Academy2]: {
     cost: Reward[],
-    income: Event[]
+    income: Event[][]
   };
   [Building.PlanetaryInstitute]: {
     cost: Reward[],
-    income: Event[]
+    income: Event[][]
   };
   [Building.GaiaFormer]: {
     cost: Reward[],
-    income: Event[]
+    income: Event[][]
   };
   income: Event[];
   power: {
@@ -115,19 +118,21 @@ export class FactionBoard {
     area2: number
   };
   brainstone: BrainstoneArea;
+  handlers?: {[event: string]: (player: Player, ...args: any[]) => any};
 
   constructor(input: FactionBoardRaw) {
     Object.assign(this, _.merge({}, defaultBoard, input));
 
     const buildings = Object.values(Building).filter(bld => bld !== Building.SpaceStation);
     const toRewards = [`${Building.TradingStation}.isolatedCost`].concat(buildings.map(bld => `${bld}.cost`));
-    const toIncome = ["income"].concat(buildings.map(bld => `${bld}.income`));
+    const toIncome = buildings.map(bld => `${bld}.income`);
 
     for (const toRew of toRewards) {
       _.set(this, toRew, Reward.parse(_.get(this, toRew)));
     }
+    this.income = Event.parse(this.income as any);
     for (const toInc of toIncome) {
-      _.set(this, toInc, Event.parse(_.get(this, toInc)));
+      _.set(this, toInc, _.get(this, toInc).map(events => Event.parse(events)));
     }
   }
 

--- a/src/faction-boards/xenos.ts
+++ b/src/faction-boards/xenos.ts
@@ -3,7 +3,7 @@ import { Building } from "../enums";
 
 const xenos: FactionBoardRaw = {
   [Building.PlanetaryInstitute]: {
-    income: ["+4pw", "+q"]
+    income: [["+4pw", "+q"]]
   },
   income: ["3k,4o,15c,q,up-int", "+o,k"]
 };


### PR DESCRIPTION
Also:

- Move some faction-specific code to faction-board
- Move tech gain when building lab / academy to faction-board
- General clean-up of the code
- Fix double dots commands in one line (not intended)

The main change is that `subPhase` is not stored in engine. When we need to ask the player for a tech tile we do `this.processNextMove(SubPhase.TechTile)`. Same for other subphases. This avoids spreading the code around / having to stop the function. When needing to ask for some input from the player in the middle of a function, we can. This will be useful for taklons & the brainstore.

The income / gaia phase now happens player by player, for example player 2 doesn't receive income until player 1 makes their income actions. Maybe it was already the case, I'm not sure.

The move history is also stored in engine. There's a `newTurn` variable added in engine. It tells the UI whether to append a move in the current line or the next line. Currently the UI has to guess, and is not always correct.

`turnOrder` after the setup phase always indicates the order of players to play in the round. In the leech, income & gaia phases, `tempTurnOrder` is used but `turnOrder` stays the same. It also helps the UI, now it doesn't have to juggle between the two.